### PR TITLE
Add timeout to download public suffix list

### DIFF
--- a/scripts/build-tries.js
+++ b/scripts/build-tries.js
@@ -40,7 +40,7 @@ const tries = [
 
 process.stderr.write(`Downloading public suffix list from ${ PUBLIC_SUFFIX_URL }... `);
 
-got(PUBLIC_SUFFIX_URL)
+got(PUBLIC_SUFFIX_URL, { timeout: 60*1000 })
     .then(res => {
         process.stderr.write("ok" + os.EOL);
 


### PR DESCRIPTION
- Avoids default (10 minutes) timeout when unable to reach the server

ref: https://www.npmjs.com/package/got#timeout